### PR TITLE
[Feat TA-123] redirect user from login page to dashboard if logged in

### DIFF
--- a/src/hooks/useUnProtectedRoute/index.ts
+++ b/src/hooks/useUnProtectedRoute/index.ts
@@ -1,0 +1,22 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+import { UsersService } from "~/apis/handlers/users";
+import { LAYOUT_ROUTES, ROUTES } from "~/config/constants";
+
+interface IUseUnProtectedRoute {
+	path: string;
+}
+const useUnProtectedRoute = ({ path }: IUseUnProtectedRoute) => {
+	const router = useRouter();
+
+	useEffect(() => {
+		const usersService = new UsersService();
+		const userData = usersService.getDataFromToken();
+		if (userData) {
+			router.push(`${LAYOUT_ROUTES.account}${ROUTES.dashboard.homepage}`);
+			return;
+		}
+	}, [path]);
+};
+
+export default useUnProtectedRoute;

--- a/src/pages/auth/login/index.tsx
+++ b/src/pages/auth/login/index.tsx
@@ -8,8 +8,11 @@ import VerificationModal from "~/components/AuthLayout/Modal/VerificationModal";
 import { NotificationChannel, VerificationType } from "~/apis/handlers/users/enums";
 import Toast from "~/components/common/Toast";
 import AuthLayout from "../layout";
+import useUnProtectedRoute from "~/hooks/useUnProtectedRoute";
 
 const Login = () => {
+	const router = useRouter();
+	useUnProtectedRoute({ path: router.pathname });
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [passwordValid, setPasswordValid] = useState(false);
@@ -19,7 +22,6 @@ const Login = () => {
 	const [isVerificationSuccess, setIsVerificationSuccess] = useState(false);
 	const [isQueryParamsSet, setIsQueryParamsSet] = useState(false);
 
-	const router = useRouter();
 	// const [searchParams, setSearchParams] = useState(new URLSearchParams(router.asPath.split('?')[1]));
 	const usersService = new UsersService();
 


### PR DESCRIPTION
Things to note:
- Does this applies only to the login page or it also applies to signup page and other auth related pages.
- Also, currently the user sees the login page when logged in but is immediately sent to the dashboard after the session check is done.