### PR TITLE
Add functionality to resend OTP

### DIFF
--- a/src/apis/handlers/users/index.ts
+++ b/src/apis/handlers/users/index.ts
@@ -380,4 +380,17 @@ export class UsersService {
 		const { data } = response;
 		return data;
 	}
+
+	public async sendOtp({ userId }: any): Promise<void> {
+		const response = await this.apiClient.post<IResponse>({
+			url: "/auth/send-otp",
+			data: {
+				userId,
+			},
+		});
+
+		if (response.error) {
+			throw new Error(response.message || "OTP sending failed");
+		}
+	}
 }

--- a/src/components/AuthLayout/Modal/VerificationModal.tsx
+++ b/src/components/AuthLayout/Modal/VerificationModal.tsx
@@ -96,6 +96,12 @@ export default function VerificationModal({
 		}
 	};
 
+	const focusFirstInputField = () => {
+		if (inputRefs.current[0]) {
+			inputRefs.current[0].focus();
+		}
+	}
+
 	/* Check input if some have an empty string as a value */
 	const isInputsEmpty = enteredInput.some((value) => value === "");
 
@@ -116,14 +122,14 @@ export default function VerificationModal({
 	}, []);
 
 	useEffect(() => {
-		// Focus on the first input field when the component loads
-		if (inputRefs.current[0]) {
-			inputRefs.current[0].focus();
-		}
+		focusFirstInputField()
 	}, [inputRefs.current[0]]);
 
-	const restartCountdown = () => {
+	const resendOtp = () => {
+		sendOtp({ userId: userId! })
 		setCountdown(initialCountdownTime);
+		setEnteredInput(["", "", "", "", "", ""])
+		focusFirstInputField()
 	};
 
 	useEffect(() => {
@@ -144,6 +150,12 @@ export default function VerificationModal({
 		isSuccess: isVerificationSuccess,
 	} = useCreate({
 		mutationFn: usersService.verifyOtp.bind(usersService),
+	});
+
+	const {
+		mutate: sendOtp,
+	} = useCreate({
+		mutationFn: usersService.sendOtp.bind(usersService)
 	});
 
 	const handleVerification = async () => {
@@ -252,7 +264,7 @@ export default function VerificationModal({
 									Didn’t receive your code?{" "}
 									<strong
 										className={`text-[#102477] font-bold ${countdown === 0 && "cursor-pointer"}`}
-										onClick={() => countdown === 0 && restartCountdown()}
+										onClick={() => countdown === 0 && resendOtp() }
 									>
 										{countdown !== 0 ? "Retry in" : "Resend code."}
 									</strong>


### PR DESCRIPTION
- Add `sendOtp` method to `UsersService ` class
- Add `resendOtp` function to handle resending OTPs in the verification modal
- Refactor countdown display to include leading zero in seconds

<img src="https://github.com/user-attachments/assets/affbf6cc-0e57-45dc-9dc9-ac4d5fdac6e5" alt="Before" width="400"/>*Before*

<img src="https://github.com/user-attachments/assets/c88c05c6-6df8-443f-8b5d-98cacd8e1be8" alt="Before" width="400"/>*After*



