### PR TITLE
[Fix TA-226]: redirect issue on failed refresh token to preserve route

### DIFF
--- a/src/apis/handlers/users/index.ts
+++ b/src/apis/handlers/users/index.ts
@@ -151,7 +151,8 @@ export class UsersService {
 		} catch (error: any) {
 			removeAccessToken();
 			const params = new URLSearchParams();
-			params.append("redirect_to", window.location.pathname);
+			const redirectTo = new URLSearchParams(window.location.search).get("redirect_to");
+			params.append("redirect_to", redirectTo ?? window.location.pathname);
 			window.location.href = "/auth/login?" + params.toString();
 			throw new Error(`Token refresh failed: ${error.message}`);
 		}


### PR DESCRIPTION
First on visiting a protected route the user if the user's access_token is no longer valid, according the `useProtectedRoute` hook, it redirects the user to the login page. 

[1] But while this goes on the page may have made requests to an authenticated route, which triggers the refresh token action since the token is no longer valid.

The previous PRs accounted for the `useProtectedRoute` reserve route handling, but didn't for token refresh, as I simply redirected the user to `/auth/login` and didn't consider the idea that [1] may have occurred.